### PR TITLE
Added support for running as a daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM alpine:3.6
 LABEL maintainer "Kyle Lucy <kmlucy@gmail.com>"
 
-COPY ["cloudflare-update-record.sh","config.example","/"]
-
+COPY ["cloudflare-update-record.sh","config.example","start.sh","/"]
 
 RUN apk add --no-cache curl perl && \
 	mkdir /config && \
-	chmod +x /cloudflare-update-record.sh
+	chmod +x /cloudflare-update-record.sh && \
+	chmod +x /start.sh
 
 WORKDIR /config
 
 VOLUME /config
 
-CMD /cloudflare-update-record.sh
+ENV RUN_AS_DAEMON=0 DAEMON_SLEEP_TIME=600
+CMD ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#!/bin/ash
+
+if [ "$RUN_AS_DAEMON" = 1 ]; then
+    : ${DAEMON_SLEEP_TIME:=600}
+    echo "This script will update Cloudflare every $DAEMON_SLEEP_TIME seconds."
+    while true; do /cloudflare-update-record.sh; sleep $DAEMON_SLEEP_TIME; done
+else
+    /cloudflare-update-record.sh
+fi

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,6 @@
 #!/bin/ash
 
 if [ "$RUN_AS_DAEMON" = 1 ]; then
-    : ${DAEMON_SLEEP_TIME:=600}
     echo "This script will update Cloudflare every $DAEMON_SLEEP_TIME seconds."
     while true; do /cloudflare-update-record.sh; sleep $DAEMON_SLEEP_TIME; done
 else


### PR DESCRIPTION
Hey - don't know if you're maintaining this, but I used your base script to make this a bit more suited to my purpose (just leaving the image running in the background and always updating).

Commit message:
```
The default behaviour is unchanged, but it is now possible
to pass the following environment variables in the 'docker run':

RUN_AS_DAEMON=1 to enable daemon mode
DAEMON_SLEEP_TIME=60 to set the frequency (in this example, 60 seconds). default 600 seconds

Full example:

docker run  \
    -v $PWD/config:/config \
    -e RUN_AS_DAEMON=1 \
    -e DAEMON_SLEEP_TIME=60 \
    jasongwartz/docker-cloudflare
```